### PR TITLE
Modify the owners file to accomodate bz component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,5 @@ approvers:
 - fedepaol
 - SchSeba
 - mmirecki
-
+component: "Networking"
+subcomponent: "multus"


### PR DESCRIPTION
Art requires each image to declare the bz component it belongs to, and we do that by adding it to the OWNERS file.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>