### PR TITLE
Add rhel9 binary

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9
+WORKDIR /go/src/github.com/openshift/bond-cni
+COPY . .
+RUN ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
 WORKDIR /go/src/github.com/openshift/bond-cni
 COPY . .
 RUN ./build.sh
@@ -8,4 +13,6 @@ LABEL io.k8s.display-name="bond-cni" \
     io.k8s.description="This is an image containing the bond-cni executable" \
     io.openshift.tags="openshift"
 
-COPY --from=builder /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/bond
+COPY --from=rhel9 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/rhel9/bond
+COPY --from=rhel9 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/bond
+COPY --from=rhel8 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/rhel8/bond


### PR DESCRIPTION
Now that the binary is being dynamically compiled downstream, the binary must match the RHEL version of RHCOS because it is copied to the host.