### PR TITLE
NO-JIRA: Add ci-operator file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.23-openshift-4.19


### PR DESCRIPTION
This will be used by CI to set the Go build version. Openshift Release will be modified to use this file instead of the hardcoded go 1.12 version