### PR TITLE
[release-4.19] OCPBUGS-62107: Use netlinksafe instead of netlink to avoid netlink.ErrDumpInterrupted

### DIFF
--- a/bond/bond_test.go
+++ b/bond/bond_test.go
@@ -21,6 +21,7 @@ import (
 	types040 "github.com/containernetworking/cni/pkg/types/040"
 	types100 "github.com/containernetworking/cni/pkg/types/100"
 
+	"github.com/containernetworking/plugins/pkg/netlinksafe"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
@@ -125,7 +126,7 @@ var _ = Describe("bond plugin", func() {
 			err = testutils.CmdDel(podNS.Path(),
 				args.ContainerID, "", func() error { return cmdDel(args) })
 			Expect(err).NotTo(HaveOccurred())
-			_, err = netlink.LinkByName(IfName)
+			_, err = netlinksafe.LinkByName(IfName)
 			Expect(err).To(HaveOccurred())
 			return nil
 		})
@@ -182,7 +183,7 @@ var _ = Describe("bond plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("deleting a slave interface")
-			slave, err := netlink.LinkByName(Slave1)
+			slave, err := netlinksafe.LinkByName(Slave1)
 			Expect(err).NotTo(HaveOccurred())
 			err = netlink.LinkDel(slave)
 			Expect(err).NotTo(HaveOccurred())
@@ -346,7 +347,7 @@ var _ = Describe("bond plugin", func() {
 		err := podNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			slave1, err := netlink.LinkByName(Slave1)
+			slave1, err := netlinksafe.LinkByName(Slave1)
 			Expect(err).NotTo(HaveOccurred())
 
 			slave2, err := netlink.LinkByName(Slave2)
@@ -377,9 +378,9 @@ var _ = Describe("bond plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("validating the macs are not duplicated")
-			slave1, err = netlink.LinkByName(Slave1)
+			slave1, err = netlinksafe.LinkByName(Slave1)
 			Expect(err).NotTo(HaveOccurred())
-			slave2, err = netlink.LinkByName(Slave2)
+			slave2, err = netlinksafe.LinkByName(Slave2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(slave1.Attrs().HardwareAddr.String()).NotTo(Equal(slave2.Attrs().HardwareAddr.String()))
 			return nil

--- a/bond/util/validation.go
+++ b/bond/util/validation.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/netlinksafe"
 	"github.com/vishvananda/netlink"
 )
 
@@ -16,7 +18,7 @@ func ValidateMTU(slaveLinks []netlink.Link, mtu int) error {
 	if mtu < 68 {
 		return fmt.Errorf("Invalid bond MTU value (%+v), should be 68 or bigger", mtu)
 	}
-	netHandle, err := netlink.NewHandle()
+	netHandle, err := netlinksafe.NewHandle()
 	if err != nil {
 		return fmt.Errorf("Failed to create a new handle, error: %+v", err)
 	}
@@ -51,7 +53,7 @@ func ValidateMTU(slaveLinks []netlink.Link, mtu int) error {
 	return nil
 }
 
-func HandleMacDuplicates(linkObjectsToBond []netlink.Link, netNsHandle *netlink.Handle) error {
+func HandleMacDuplicates(linkObjectsToBond []netlink.Link, netNsHandle *netlinksafe.Handle) error {
 	macsInUse := []string{}
 	var err error
 	for _, link := range linkObjectsToBond {
@@ -76,7 +78,7 @@ func isMacDuplicated(mac string, macsInUse []string) bool {
 	return false
 }
 
-func updateDuplicateMac(link netlink.Link, netNsHandle *netlink.Handle, macsInUse []string) (string, error) {
+func updateDuplicateMac(link netlink.Link, netNsHandle *netlinksafe.Handle, macsInUse []string) (string, error) {
 	newMac, err := generateUnusedMac(macsInUse)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Manual cherry-pick https://github.com/openshift/bond-cni/pull/90 which fixed https://issues.redhat.com/browse/OCPBUGS-60846