### PR TITLE
OCPBUGS-83863: Remove rhel8 build stage

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,16 +3,9 @@ WORKDIR /go/src/github.com/openshift/bond-cni
 COPY . .
 RUN go build --mod=vendor -ldflags '-s -w' -o ./bin/bond ./bond/
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-5.0 AS rhel8
-WORKDIR /go/src/github.com/openshift/bond-cni
-COPY . .
-RUN go build --mod=vendor -ldflags '-s -w' -o ./bin/bond ./bond/
-
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 LABEL io.k8s.display-name="bond-cni" \
     io.k8s.description="This is an image containing the bond-cni executable" \
     io.openshift.tags="openshift"
 
-COPY --from=rhel9 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/rhel9/bond
 COPY --from=rhel9 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/bond
-COPY --from=rhel8 /go/src/github.com/openshift/bond-cni/bin/bond /bondcni/rhel8/bond


### PR DESCRIPTION
The rhel9/rhel10 version-specific subdirectories are no longer needed
since openshift/cluster-network-operator#2967 removed the OS detection
logic and now copies binaries directly from the base directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated the container build to a single builder stage for simpler, more maintainable images.
  * Unified runtime binary placement to a single location with compatibility symlinks for consistent deployments.
  * Optimized compilation to strip symbol/debug information, reducing binary and image size and improving startup performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->