### PR TITLE
Align ose-network-interface-bond-cni-container image with ART for 4.12

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.19-openshift-4.12


### PR DESCRIPTION
This PR is an effort to align with the ART builder for 4.12.

Additionally https://github.com/openshift/release/pull/79098 removes the dependency on https://github.com/openshift/release for the build root image used by the componen's branch specific CI.