### PR TITLE
NO-JIRA: Update OWNERS: remove zshi-redhat

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-- zshi-redhat
 - fedepaol
 - SchSeba
 - karampok
 approvers:
-- zshi-redhat
 - fedepaol
 - SchSeba
 - karampok


### PR DESCRIPTION
## Summary
- Remove zshi-redhat from reviewers and approvers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the maintainers and reviewers configuration for the Networking component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->